### PR TITLE
feat: add video overlay component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8376,6 +8376,11 @@
         }
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-fs-cache": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
@@ -13900,6 +13905,16 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-youtube": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/react-youtube/-/react-youtube-7.9.0.tgz",
+      "integrity": "sha512-2+nBF4qP8nStYEILIO1/SylKOCnnJUxuZm+qCeWA0eeZxnWZIIixfAeAqbzblwx5L1n/26ACocy3epm9Glox8w==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "prop-types": "^15.5.3",
+        "youtube-player": "^5.5.1"
+      }
+    },
     "reactstrap": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-7.1.0.tgz",
@@ -15274,6 +15289,11 @@
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
+    },
+    "sister": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.1.tgz",
+      "integrity": "sha512-aG41gNRHRRxPq52MpX4vtm9tapnr6ENmHUx8LMAJWCOplEMwXzh/dp5WIo52Wl8Zlc/VUyHLJ2snX0ck+Nma9g=="
     },
     "sisteransi": {
       "version": "0.1.1",
@@ -17592,6 +17612,31 @@
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "requires": {
         "camelcase": "^4.1.0"
+      }
+    },
+    "youtube-player": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+      "requires": {
+        "debug": "^2.6.6",
+        "load-script": "^1.0.0",
+        "sister": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-redux-i18n": "^1.9.3",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.3",
+    "react-youtube": "^7.9.0",
     "reactstrap": "^7.1.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0"

--- a/src/components/VideoOverlay.js
+++ b/src/components/VideoOverlay.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react';
+import YouTube from 'react-youtube';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Modal,
+  ModalHeader,
+  ModalBody,
+} from 'reactstrap';
+
+class VideoOverlay extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      modal: false,
+    };
+    this.toggle = this.toggle.bind(this);
+  }
+
+  toggle() {
+    this.setState({
+      modal: !this.state.modal,
+    });
+  }
+
+  render() {
+    const {
+      id,
+      height,
+      title,
+      buttonTitle,
+    } = this.props;
+
+    const videoOpts = {
+      height,
+      width: '100%',
+      playerVars: {
+        autoplay: 1,
+      },
+    };
+
+    return (
+      <div>
+        <Button color="primary" onClick={this.toggle}>
+          {buttonTitle}
+        </Button>
+        <Modal isOpen={this.state.modal} toggle={this.toggle}>
+          <ModalHeader toggle={this.toggle}>
+            {title}
+          </ModalHeader>
+          <ModalBody>
+            <YouTube opts={videoOpts} videoId={id}></YouTube>
+          </ModalBody>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+VideoOverlay.defaultProps = {
+  height: '300px',
+};
+
+VideoOverlay.propTypes = {
+  height: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  buttonTitle: PropTypes.string.isRequired,
+};
+
+export default VideoOverlay;


### PR DESCRIPTION
# Props:
  height: `string`, (default: `300px`)
  id: `string`,
  buttonTitle: `string`,
  title: `string`, // optional